### PR TITLE
Added related terms to JSON-LD export

### DIFF
--- a/app/controllers/concepts/openactive_controller.rb
+++ b/app/controllers/concepts/openactive_controller.rb
@@ -90,10 +90,10 @@ class Concepts::OpenactiveController < ConceptsController
         render json: raw_hash
         pretty_json = JSON.pretty_generate(raw_hash)
         client = Octokit::Client.new(:login => ENV["GIT_UID"], :password => ENV["GIT_PSW"])
-        orig_file = client.contents("openactive/activity-list", :path => 'unvalidated_activity_list-test.jsonld')
+        orig_file = client.contents("openactive/activity-list", :path => 'unvalidated_activity_list.jsonld')
         sha = orig_file[:sha]
         client.create_contents("openactive/activity-list",
-                 "unvalidated_activity_list-test.jsonld",
+                 "unvalidated_activity_list.jsonld",
                  "Adding unvalidated content",
                  pretty_json,
                  :branch => "master",

--- a/app/controllers/concepts/openactive_controller.rb
+++ b/app/controllers/concepts/openactive_controller.rb
@@ -49,6 +49,10 @@ class Concepts::OpenactiveController < ConceptsController
           c.narrower_relations.each do |rel|
             narrower << "https://openactive.io/activity-list##{rel.target.origin[1..-1]}"
           end
+          related = []
+          c.referenced_relations.each do |rel|
+            related << "https://openactive.io/activity-list##{rel.target.origin[1..-1]}"
+          end
           concept = {
               id: url,
               identifier: c.origin[1..-1],
@@ -57,6 +61,7 @@ class Concepts::OpenactiveController < ConceptsController
           }
           concept[:broader] = broader if broader.any?
           concept[:narrower] = narrower if narrower.any?
+          concept[:related] = related if related.any?
           c.notes_for_class(Note::SKOS::Definition).each do |n|
             concept[:definition] = n.value
           end

--- a/app/controllers/concepts/openactive_controller.rb
+++ b/app/controllers/concepts/openactive_controller.rb
@@ -88,7 +88,7 @@ class Concepts::OpenactiveController < ConceptsController
         render json: raw_hash
         pretty_json = JSON.pretty_generate(raw_hash)
         client = Octokit::Client.new(:login => ENV["GIT_UID"], :password => ENV["GIT_PSW"])
-        orig_file = client.contents("openactive/activity-list", :path => 'unvalidated_activity_list.jsonld')
+        orig_file = client.contents("openactive/activity-list", :path => 'unvalidated_activity_list-test.jsonld')
         sha = orig_file[:sha]
         client.create_contents("openactive/activity-list",
                  "unvalidated_activity_list.jsonld",

--- a/app/controllers/concepts/openactive_controller.rb
+++ b/app/controllers/concepts/openactive_controller.rb
@@ -91,7 +91,7 @@ class Concepts::OpenactiveController < ConceptsController
         orig_file = client.contents("openactive/activity-list", :path => 'unvalidated_activity_list-test.jsonld')
         sha = orig_file[:sha]
         client.create_contents("openactive/activity-list",
-                 "unvalidated_activity_list.jsonld",
+                 "unvalidated_activity_list-test.jsonld",
                  "Adding unvalidated content",
                  pretty_json,
                  :branch => "master",

--- a/app/controllers/concepts/openactive_controller.rb
+++ b/app/controllers/concepts/openactive_controller.rb
@@ -49,8 +49,10 @@ class Concepts::OpenactiveController < ConceptsController
           c.narrower_relations.each do |rel|
             narrower << "https://openactive.io/activity-list##{rel.target.origin[1..-1]}"
           end
+          klass = Iqvoc::Concept.further_relation_classes.first # XXX: arbitrary; bad heuristic?
+          only_published = params[:published] != "0"
           related = []
-          c.related_concepts.each do |related_concept|
+          c.related_concepts_for_relation_class(klass, only_published).each do |related_concept|
             related << "https://openactive.io/activity-list##{related_concept.origin[1..-1]}"
           end
           concept = {

--- a/app/controllers/concepts/openactive_controller.rb
+++ b/app/controllers/concepts/openactive_controller.rb
@@ -50,8 +50,8 @@ class Concepts::OpenactiveController < ConceptsController
             narrower << "https://openactive.io/activity-list##{rel.target.origin[1..-1]}"
           end
           related = []
-          c.referenced_relations.each do |rel|
-            related << "https://openactive.io/activity-list##{rel.target.origin[1..-1]}"
+          c.related_concepts.each do |related_concept|
+            related << "https://openactive.io/activity-list##{related_concept.origin[1..-1]}"
           end
           concept = {
               id: url,


### PR DESCRIPTION
`related` terms are missing from the OA activity list outputted by `/app/controllers/concepts/openactive_controller.rb`.

I believe this was in use by EMD (need to check, they may have never used it)… either way is good info to include and can see it’s still in iqvoc (https://activity-list.openactive.io/en/concepts/_1ae7395a-27a7-4e33-9f6d-a1a6c17d0757.html), and is useful reference data.

I've created a quick PR for this - not sure how to test this though as it's closely tied to GitHub.

@thill-odi maybe easier for you to do if you've already got a dev environment set up for this?