### PR TITLE
Remove rubyracer for heroku 20 deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :production do
 end
 
 platforms :ruby do
-  gem 'therubyracer'
+  # gem 'therubyracer' # Not needed for deployment to heroku, not is the newer mini_racer
 end
 
 group :heroku do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,6 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
-    libv8 (3.16.14.19)
     link_header (0.0.8)
     linkeddata (3.0.3)
       equivalent-xml (~> 0.6)
@@ -342,7 +341,6 @@ GEM
     rdf-xsd (3.1.1)
       rdf (~> 3.1)
       rexml (~> 3.2)
-    ref (2.0.0)
     request_store (1.5.0)
       rack (>= 1.4)
     rexml (3.2.5)
@@ -400,9 +398,6 @@ GEM
     sxp (1.1.0)
       rdf (~> 3.1)
     temple (0.8.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -478,7 +473,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   simplecov
   sqlite3 (~> 1.3.0)
-  therubyracer
   uglifier
   view_marker
   web-console


### PR DESCRIPTION
Because we can no longer deploy to heroku-18, in order to changes the links to the new feedback form
- Update the html.erb files
- Update to 2.6.10 (last supported version on heroku-20, not supported on heroku-22)
- Remove rubyracer as not needed for heroku deployment and was causing errors with libv8